### PR TITLE
Implement setters for Checker properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ You may need to prefix these commands with a call to the Python interpreter depe
 
 To get started checking your python projects with len8:
 
+#### Using the terminal
+
 ```sh
 # Check all files in the cwd
 len8 .
@@ -69,6 +71,28 @@ len8 ./dir/important.py
 
 # Check using multiple flags at once
 len8 -lx ignoreme.py ./project_dir
+```
+
+#### In a Python script
+
+```py
+from len8 import Checker
+
+
+# Instantiate a new Checker, with strict mode set to True
+checker = Checker(strict=True)
+
+# Set attributes after instantiation
+checker.extend = True
+checker.exclude = ["excluded_dir"]
+checker.strict = False
+
+# Checks everything in the cwd
+bad_lines = checker.check(".")
+
+# Because strict mode is set to False and no error is raised, we
+# print the returned value from the check method
+print(bad_lines)
 ```
 
 ## Contributing

--- a/len8/__main__.py
+++ b/len8/__main__.py
@@ -34,7 +34,11 @@ from len8.models import Checker, Parser
 
 def main():
     parser = Parser()
-    checker = Checker(exclude=parser.exclude, extend=parser.extend)
+    checker = Checker(
+        exclude=parser.exclude,
+        extend=parser.extend,
+        strict=True,
+    )
 
     try:
         checker.check(*parser.paths)

--- a/len8/models/checker.py
+++ b/len8/models/checker.py
@@ -49,9 +49,9 @@ class Checker:
 
     def __init__(
         self,
-        exclude: t.List[str] = [".nox", ".venv", "venv"],
+        exclude: t.List[str] = [],
         extend: bool = False,
-        strict: bool = True,
+        strict: bool = False,
     ) -> None:
         self._exclude = exclude
         self._extend = extend
@@ -76,12 +76,20 @@ class Checker:
     @property
     def exclude(self) -> t.List[str]:
         """A list of paths to exclude from checking."""
-        return self._exclude
+        return [".nox", ".venv", "venv", *self._exclude]
+
+    @exclude.setter
+    def exclude(self, excludes: t.List[str]) -> None:
+        self._exclude = excludes
 
     @property
     def extend(self) -> bool:
         """If True, increase acceptable line length to 99."""
         return self._extend
+
+    @extend.setter
+    def extend(self, extend: bool) -> None:
+        self._extend = extend
 
     @property
     def strict(self) -> bool:
@@ -89,6 +97,10 @@ class Checker:
         reason.
         """
         return self._strict
+
+    @strict.setter
+    def strict(self, strict: bool) -> None:
+        self._strict = strict
 
     def check(self, *paths: str) -> t.Optional[str]:
         """Checks to ensure line lengths conform to PEP 8 standards.

--- a/len8/models/parser.py
+++ b/len8/models/parser.py
@@ -44,10 +44,7 @@ class Parser:
     @property
     def exclude(self) -> t.List[str]:
         """The list of files/dirs to exclude."""
-        if len(self._args.exclude) == 1:
-            return self._args.exclude[0]
-
-        return self._args.exclude
+        return self._args.exclude[0] if self._args.exclude else []
 
     @property
     def extend(self) -> bool:
@@ -60,9 +57,7 @@ class Parser:
         return self._args.paths
 
     def _gather_excludes(self, e: str) -> t.List[str]:
-        excludes = [".venv", "venv", ".nox"]
-        excludes.extend(e.split(","))
-        return excludes
+        return e.split(",")
 
     def _parse(self):
         self._parser.add_argument("paths", nargs="+")
@@ -72,7 +67,6 @@ class Parser:
             metavar="filepath",
             type=self._gather_excludes,
             nargs=1,
-            default=[".venv", "venv", ".nox"],
             help="comma separated list of files/dirs to exclude",
         )
         self._parser.add_argument(

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -10,7 +10,7 @@ def default_checker() -> len8.Checker:
 
 @pytest.fixture()
 def custom_checker() -> len8.Checker:
-    return len8.Checker(exclude=["custom"], extend=True, strict=False)
+    return len8.Checker(exclude=["custom"], extend=True, strict=True)
 
 
 def test_default_init(default_checker: len8.Checker) -> None:
@@ -18,12 +18,12 @@ def test_default_init(default_checker: len8.Checker) -> None:
     assert default_checker.exclude == [".nox", ".venv", "venv"]
     assert default_checker.extend is False
     assert default_checker.bad_lines is None
-    assert default_checker.strict is True
+    assert default_checker.strict is False
 
 
 def test_custom_init(custom_checker: len8.Checker) -> None:
     assert isinstance(custom_checker, len8.Checker)
-    assert custom_checker.exclude == ["custom"]
+    assert custom_checker.exclude == [".nox", ".venv", "venv", "custom"]
     assert custom_checker.extend is True
     assert custom_checker.bad_lines is None
-    assert custom_checker.strict is False
+    assert custom_checker.strict is True


### PR DESCRIPTION
### Summary
<!-- Summary of the pull request -->
This pull request:
- Adds an `@setter` for each of the values passed to the `Checker`'s constructor allowing them to be altered after instantiation. 
- Adds an example of using the `Checker` in a Python script to the README.
- Fixes a bug where the default excludes would be overwritten if custom ones were set.

### Tasks
<!-- [ ] = No, [x] = Yes -->
- [x] I have searched for similar/duplicate PR's, and there are none.
- [x] I have made tests to validate any changes to the code base.
- [x] I have run `nox` and all sessions pass.

### Related issues
<!-- Related issues go here. `Closes #5` `Fixes #3` -->
Closes #7 
Closes #8 
