### PR TITLE
Add pathlib support

### DIFF
--- a/len8/__main__.py
+++ b/len8/__main__.py
@@ -32,7 +32,7 @@ from len8.errors import BadLines, InvalidPath
 from len8.models import Checker, Parser
 
 
-def main():
+def main() -> None:
     parser = Parser()
     checker = Checker(
         exclude=parser.exclude,

--- a/len8/errors.py
+++ b/len8/errors.py
@@ -28,6 +28,8 @@
 
 __all__ = ["BadLines", "InvalidPath", "Len8Error"]
 
+from pathlib import Path
+
 
 class Len8Error(Exception):
     """Base exception all len8 errors inherit from."""
@@ -40,7 +42,7 @@ class BadLines(Len8Error):
 class InvalidPath(Len8Error):
     """Raised when an invalid path is passed to be checked."""
 
-    def __init__(self, arg: str) -> None:
+    def __init__(self, arg: Path) -> None:
         self.arg = arg
 
     def __str__(self) -> str:

--- a/len8/models/checker.py
+++ b/len8/models/checker.py
@@ -49,6 +49,7 @@ class Checker:
 
     def __init__(
         self,
+        *,
         exclude: t.Sequence[t.Union[Path, str]] = [],
         extend: bool = False,
         strict: bool = False,
@@ -127,6 +128,9 @@ class Checker:
             return False
 
         for e in self.exclude:
+            if path.absolute() == e:
+                return False
+
             if path.is_relative_to(e):
                 return False
 

--- a/len8/models/checker.py
+++ b/len8/models/checker.py
@@ -35,16 +35,16 @@ from len8 import errors
 class Checker:
     """An object used to check line lengths.
 
-    Args:
-        exclude: list[str]
-            A list of paths to exclude from checking. Defaults to
-            [".nox", ".venv", "venv"].
+    Keyword Args:
+        exclude: list[pathlib.Path | str]
+            A list of paths on top of the defaults (.nox, .venv, and
+            venv) to exclude from checking. Defaults to an empty list.
         extend: bool
             Whether or not to increase acceptable line length to 99.
-            Defaults to False.
+            Defaults to ``False``.
         strict: bool
             If True, raises an error if the check method fails. Defaults
-            to True.
+            to ``True``.
     """
 
     def __init__(
@@ -69,7 +69,10 @@ class Checker:
     @property
     def bad_lines(self) -> t.Union[str, None]:
         """A formatted string containing the lines that were too long
-        during the last check, or None if there were none.
+        during the last check, or ``None`` if there were none.
+
+        Returns:
+            ``str`` | ``None``
         """
         if not self._bad_lines:
             return None
@@ -81,7 +84,11 @@ class Checker:
 
     @property
     def exclude(self) -> t.List[Path]:
-        """A list of paths to exclude from checking."""
+        """A list of paths to exclude from checking.
+
+        Returns:
+            ``list[pathlib.Path]``
+        """
         return [Path(".nox"), Path(".venv"), Path("venv"), *self._exclude]
 
     @exclude.setter
@@ -90,7 +97,11 @@ class Checker:
 
     @property
     def extend(self) -> bool:
-        """If True, increase acceptable line length to 99."""
+        """If ``True``, increase acceptable line length to 99.
+
+        Returns:
+            ``bool``
+        """
         return self._extend
 
     @extend.setter
@@ -99,8 +110,11 @@ class Checker:
 
     @property
     def strict(self) -> bool:
-        """If True, raises an error if the check method fails for any
-        reason.
+        """If ``True``, raises an error if the check method fails for
+        any reason.
+
+        Returns:
+            ``bool``
         """
         return self._strict
 
@@ -160,6 +174,25 @@ class Checker:
                     in_docs = False
 
     def check(self, *paths: t.Union[Path, str]) -> t.Optional[str]:
+        """Checks to ensure the line lengths conform to PEP 8 standards.
+
+        Args:
+            *paths: ``Path`` | ``str``
+                The path or paths to check.
+
+        Returns:
+            ``str`` | ``None``
+                A formatted string containing the lines that were too
+                long, or ``None`` if there were none.
+
+        Raises:
+            :obj:`InvalidPath`:
+                If strict mode is set to ``True`` and the given path
+                does not exist.
+            :obj:`BadLines`:
+                If strict mode is set to ``True`` and the files that
+                were checked contained lines what were too long.
+        """
         for p in paths:
             if not isinstance(p, Path):
                 p = Path(p)

--- a/len8/models/parser.py
+++ b/len8/models/parser.py
@@ -28,6 +28,7 @@
 
 import argparse
 import typing as t
+from pathlib import Path
 
 
 class Parser:
@@ -42,32 +43,38 @@ class Parser:
         self._parse()
 
     @property
-    def exclude(self) -> t.List[str]:
+    def exclude(self) -> t.List[Path]:
         """The list of files/dirs to exclude."""
-        return self._args.exclude[0] if self._args.exclude else []
+        return t.cast(t.List[Path], self._args.exclude)
 
     @property
     def extend(self) -> bool:
         """Whether or not to increase acceptable line length to 99."""
-        return self._args.length
+        return t.cast(bool, self._args.length)
 
     @property
     def paths(self) -> t.List[str]:
         """The list of paths to check."""
-        return self._args.paths
+        return t.cast(t.List[str], self._args.paths)
 
-    def _gather_excludes(self, e: str) -> t.List[str]:
-        return e.split(",")
+    def _as_path_per(self, value: str) -> Path:
+        return Path(value)
 
-    def _parse(self):
-        self._parser.add_argument("paths", nargs="+")
+    def _as_paths(self, value: str) -> t.List[Path]:
+        if not value:
+            return []
+
+        return [Path(p) for p in value.split(",")]
+
+    def _parse(self) -> None:
+        self._parser.add_argument("paths", type=self._as_path_per, nargs="+")
         self._parser.add_argument(
             "-x",
             "--exclude",
-            metavar="filepath",
-            type=self._gather_excludes,
-            nargs=1,
             help="comma separated list of files/dirs to exclude",
+            metavar="filepath",
+            default="",
+            type=self._as_paths,
         )
         self._parser.add_argument(
             "-l",

--- a/len8/models/parser.py
+++ b/len8/models/parser.py
@@ -44,17 +44,29 @@ class Parser:
 
     @property
     def exclude(self) -> t.List[Path]:
-        """The list of files/dirs to exclude."""
+        """The list of files/dirs to exclude.
+
+        Returns:
+            ``list[pathlib.Path]``
+        """
         return t.cast(t.List[Path], self._args.exclude)
 
     @property
     def extend(self) -> bool:
-        """Whether or not to increase acceptable line length to 99."""
+        """Whether or not to increase acceptable line length to 99.
+
+        Returns:
+            ``bool``
+        """
         return t.cast(bool, self._args.length)
 
     @property
     def paths(self) -> t.List[str]:
-        """The list of paths to check."""
+        """The list of paths to check.
+
+        Returns:
+            ``list[str]``
+        """
         return t.cast(t.List[str], self._args.paths)
 
     def _as_path_per(self, value: str) -> Path:

--- a/len8/models/parser.py
+++ b/len8/models/parser.py
@@ -69,9 +69,6 @@ class Parser:
         """
         return t.cast(t.List[str], self._args.paths)
 
-    def _as_path_per(self, value: str) -> Path:
-        return Path(value)
-
     def _as_paths(self, value: str) -> t.List[Path]:
         if not value:
             return []
@@ -79,7 +76,7 @@ class Parser:
         return [Path(p) for p in value.split(",")]
 
     def _parse(self) -> None:
-        self._parser.add_argument("paths", type=self._as_path_per, nargs="+")
+        self._parser.add_argument("paths", type=Path, nargs="+")
         self._parser.add_argument(
             "-x",
             "--exclude",

--- a/noxfile.py
+++ b/noxfile.py
@@ -110,7 +110,8 @@ def check_imports(session: nox.Session) -> None:
 
 @nox.session(reuse_venv=True)
 def check_typing(session: nox.Session) -> None:
-    session.install("-U", DEPS["pyright"])
+    session.install("-U", DEPS["mypy"], DEPS["pyright"])
+    session.run("mypy", "len8", "--strict")
     session.run("pyright")
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ build~=0.7.0
 flake8~=4.0.0
 furo~=2021.10.9
 isort~=5.9.3
+mypy~=0.910
 nox~=2021.10.1
 pyright~=0.0.11
 git+https://github.com/pytest-dev/py; python_version == "3.11"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -26,6 +26,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from pathlib import Path
+
 import pytest  # type: ignore
 
 import len8
@@ -43,7 +45,11 @@ def custom_checker() -> len8.Checker:
 
 def test_default_init(default_checker: len8.Checker) -> None:
     assert isinstance(default_checker, len8.Checker)
-    assert default_checker.exclude == [".nox", ".venv", "venv"]
+    assert default_checker.exclude == [
+        Path(".nox"),
+        Path(".venv"),
+        Path("venv"),
+    ]
     assert default_checker.extend is False
     assert default_checker.bad_lines is None
     assert default_checker.strict is False
@@ -51,7 +57,12 @@ def test_default_init(default_checker: len8.Checker) -> None:
 
 def test_custom_init(custom_checker: len8.Checker) -> None:
     assert isinstance(custom_checker, len8.Checker)
-    assert custom_checker.exclude == [".nox", ".venv", "venv", "custom"]
+    assert custom_checker.exclude == [
+        Path(".nox"),
+        Path(".venv"),
+        Path("venv"),
+        Path("custom"),
+    ]
     assert custom_checker.extend is True
     assert custom_checker.bad_lines is None
     assert custom_checker.strict is True


### PR DESCRIPTION
### Summary
This PR modifies the API to utilise the power of `pathlib`. It also fixes some typehinting errors Pyright didn't pick up. There's a new Mypy test within the noxfile, though the Pyright one has been retained.

### Tasks
- [x] I have searched for similar/duplicate PR's, and there are none.
- [x] I have made tests to validate any changes to the code base.
- [x] I have run `nox` and all sessions pass.

### Related issues
Closes #6.
