### PR TITLE
Add support for toml configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,34 @@ bad_lines = checker.check(".")
 print(bad_lines)
 ```
 
+## Configuration
+
+len8 supports toml configuration files, by default `pyproject.toml` in your project
+root will be used. You may specify a different configuration file via the `--config`
+cli flag.
+
+```toml
+[tool.len8]
+include = ["myapp"]
+exclude = ["secrets", "testing"]
+code-length = 88
+docs-length = 69
+strict = true
+```
+
+It's easy to take advantage of configuration files from a Python script as well.
+
+```py
+from len8 import Checker, Config
+
+# Valid
+checker = Checker.from_config("./myconfig.toml")
+
+# Also valid
+cfg = Config("./myconfig.toml")
+checker = Checker.from_config(cfg)
+```
+
 ## Contributing
 
 len8 is open to contributions. To find out where to get started, have a look at the [contributing guide](https://github.com/parafoxia/len8/blob/main/CONTRIBUTING.md).

--- a/len8/__init__.py
+++ b/len8/__init__.py
@@ -26,7 +26,14 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__all__ = ["BadLines", "Checker" ,"InvalidPath", "Len8Error", "Config"]
+__all__ = [
+    "BadLines",
+    "Checker",
+    "Config",
+    "ConfigurationError",
+    "InvalidPath",
+    "Len8Error",
+]
 
 __productname__ = "len8"
 __version__ = "0.5.0"

--- a/len8/__init__.py
+++ b/len8/__init__.py
@@ -26,7 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__all__ = ["BadLines", "Checker" ,"InvalidPath", "Len8Error"]
+__all__ = ["BadLines", "Checker" ,"InvalidPath", "Len8Error", "Config"]
 
 __productname__ = "len8"
 __version__ = "0.5.0"
@@ -38,5 +38,5 @@ __license__ = "BSD-3-Clause"
 __bugtracker__ = "https://github.com/parafoxia/len8/issues"
 __ci__ = "https://github.com/parafoxia/len8/actions"
 
-from .checker import Checker
+from .checker import Checker, Config
 from .errors import *

--- a/len8/checker.py
+++ b/len8/checker.py
@@ -38,10 +38,10 @@ class Config:
     """A ``len8`` configuration generated from a toml file."""
 
     __slots__: t.Sequence[str] = (
-        "_include",
-        "_exclude",
         "_code_length",
         "_docs_length",
+        "_include",
+        "_exclude",
         "_is_configured",
         "_strict",
     )
@@ -133,6 +133,15 @@ class Checker:
             If True, raises an error if the check method fails. Defaults
             to ``True``.
     """
+
+    __slots__: t.Sequence[str] = (
+        "_bad_lines",
+        "_code_length",
+        "_docs_length",
+        "_exclude",
+        "_extend",
+        "_strict",
+    )
 
     def __init__(
         self,

--- a/len8/checker.py
+++ b/len8/checker.py
@@ -189,9 +189,6 @@ class Checker:
         if not isinstance(config, Config):
             config = Config(config)
 
-        if not config.is_configured:
-            return cls()
-
         return cls(
             exclude=config.exclude or [],
             max_code_length=config.code_length,

--- a/len8/checker.py
+++ b/len8/checker.py
@@ -26,9 +26,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import toml
 import typing as t
 from pathlib import Path
+
+import toml
 
 from len8 import errors
 

--- a/len8/checker.py
+++ b/len8/checker.py
@@ -337,7 +337,7 @@ class Checker:
                     if rs.endswith('"""'):
                         in_docs = False
 
-        except IsADirectoryError:
+        except (IsADirectoryError, PermissionError):
             # Handle weird directories.
             ...
 

--- a/len8/checker.py
+++ b/len8/checker.py
@@ -59,7 +59,7 @@ class Config:
 
         if not path.is_file():
             raise errors.ConfigurationError(
-                f"'{path}' is a directory, or does not exist"
+                f"'{path}' is not a valid configuration file."
             )
 
         with open(path) as f:

--- a/len8/cli.py
+++ b/len8/cli.py
@@ -108,6 +108,8 @@ def len8(
 
     else:
         checker = Checker.from_config(cfg)
+        checker.set_lengths(code=code_length or -1, docs=docs_length or -1)
+        checker.exclude = list(exclude) or checker.exclude
 
     try:
         if paths:

--- a/len8/cli.py
+++ b/len8/cli.py
@@ -110,6 +110,7 @@ def len8(
     else:
         checker = Checker.from_config(cfg)
         checker.strict = True
+        checker.extend = extend_length
         checker.set_lengths(code=code_length or -1, docs=docs_length or -1)
 
         if exclude:

--- a/len8/cli.py
+++ b/len8/cli.py
@@ -97,7 +97,8 @@ def len8(
     try:
         cfg = Config(config)
 
-    except ConfigurationError:
+    except ConfigurationError as e:
+        print(e)
         checker = Checker(
             exclude=exclude,
             extend=min(extend_length, 2),

--- a/len8/cli.py
+++ b/len8/cli.py
@@ -108,8 +108,11 @@ def len8(
 
     else:
         checker = Checker.from_config(cfg)
+        checker.strict = True
         checker.set_lengths(code=code_length or -1, docs=docs_length or -1)
-        checker.exclude = list(exclude) or checker.exclude
+
+        if exclude:
+            checker.exclude = list(exclude)
 
     try:
         if paths:

--- a/len8/errors.py
+++ b/len8/errors.py
@@ -26,7 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__all__ = ["BadLines", "InvalidPath", "Len8Error"]
+__all__ = ["Len8Error", "BadLines", "ConfigurationError", "InvalidPath"]
 
 from pathlib import Path
 
@@ -37,6 +37,10 @@ class Len8Error(Exception):
 
 class BadLines(Len8Error):
     """Raised when a file contains lines that are too long."""
+
+
+class ConfigurationError(Len8Error):
+    """Raised when configuration of the Checker fails."""
 
 
 class InvalidPath(Len8Error):

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,7 +113,6 @@ def check_typing(session: nox.Session) -> None:
     session.install(
         "-U",
         DEPS["mypy"],
-        "-U",
         DEPS["types-toml"],
         "-r",
         "requirements.txt",

--- a/noxfile.py
+++ b/noxfile.py
@@ -110,7 +110,14 @@ def check_imports(session: nox.Session) -> None:
 
 @nox.session(reuse_venv=True)
 def check_typing(session: nox.Session) -> None:
-    session.install("-U", DEPS["mypy"], "-r", "requirements.txt")
+    session.install(
+        "-U",
+        DEPS["mypy"],
+        "-U",
+        DEPS["types-toml"],
+        "-r",
+        "requirements.txt",
+    )
     session.run("mypy", "len8", "tests")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-extend-exclude = "len8/__init__.py|tests/testdata.py"
+extend-exclude = "len8/__init__.py|tests/testdata.py|tests/exclude.py"
 line-length = 79
 
 [tool.isort]
@@ -15,4 +15,4 @@ profile = "black"
 [tool.mypy]
 strict = true
 ignore_missing_imports = true
-exclude = "tests/testdata.py"
+exclude = "tests/testdata.py|tests/exclude.py"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ nox~=2021.10.1
 pytest~=6.2.0; python_version <= "3.10"
 git+https://github.com/pytest-dev/py; python_version == "3.11"
 sphinx~=4.2.0
+types-toml~=0.10.1

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@
 
 import sys
 import typing as t
+from collections import defaultdict
 
 if sys.version_info < (3, 6, 0):
     print(
@@ -46,30 +47,30 @@ def parse_requirements(path: str) -> t.List[str]:
 
 
 with open("./len8/__init__.py") as f:
-    (
-        productname,
-        version,
-        description,
-        url,
-        docs,
-        author,
-        license_,
-        bug_tracker,
-        ci,
-    ) = [l.split('"')[1] for l in f.readlines()[30:39]]
+    attrs = defaultdict(str)
+
+    for line in f:
+        if not line.startswith("__"):
+            continue
+
+        k, v = line.split(" = ")
+        if k == "__all__":
+            continue
+
+        attrs[k[2:-2]] = v.strip().replace('"', "")
 
 with open("./README.md") as f:
     long_description = f.read()
 
 setuptools.setup(
-    name=productname,
-    version=version,
-    description=description,
+    name=attrs["productname"],
+    version=attrs["version"],
+    description=attrs["description"],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url=url,
-    author=author,
-    license=license_,
+    url=attrs["url"],
+    author=attrs["author"],
+    license=attrs["license_"],
     classifiers=[
         # "Development Status :: 1 - Planning",
         # "Development Status :: 2 - Pre-Alpha",
@@ -98,10 +99,10 @@ setuptools.setup(
         "Typing :: Typed",
     ],
     project_urls={
-        "Documentation": docs,
-        "Source": url,
-        "Bug Tracker": bug_tracker,
-        "CI": ci,
+        "Documentation": attrs["docs"],
+        "Source": attrs["url"],
+        "Bug Tracker": attrs["bug_tracker"],
+        "CI": attrs["ci"],
     },
     install_requires=parse_requirements("./requirements.txt"),
     entry_points={"console_scripts": ["len8 = len8.cli:len8"]},

--- a/tests/exclude.py
+++ b/tests/exclude.py
@@ -1,0 +1,2 @@
+# Copyright (c) Whoever, whenever
+the_truth = "We should never have to deal with this file, it's only purpose to be excluded!"

--- a/tests/test.toml
+++ b/tests/test.toml
@@ -1,0 +1,6 @@
+[tool.len8]
+include = ["tests/testdata.py"]
+exclude = ["tests/exclude.py"]
+code-length = 88
+docs-length = 69
+strict = true

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -35,6 +35,8 @@ from len8.errors import BadLines, InvalidPath
 
 TEST_FILE = Path(__file__).parent / "testdata.py"
 TEST_NON_VALID = TEST_FILE.parent / "nsx_simple_app.nsx"
+TEST_TOML_CONFIG = TEST_FILE.parent / "test.toml"
+TEST_LOL_TOML_CONFIG = TEST_FILE.parent / "test_lol.toml"
 
 
 @pytest.fixture()  # type: ignore
@@ -52,6 +54,11 @@ def extended_checker() -> len8.Checker:
 @pytest.fixture()  # type: ignore
 def custom_checker() -> len8.Checker:
     return len8.Checker(max_code_length=100, max_docs_length=80)
+
+
+@pytest.fixture()  # type: ignore
+def valid_config() -> len8.Config:
+    return len8.Config(TEST_TOML_CONFIG)
 
 
 def test_default_init(default_checker: len8.Checker) -> None:
@@ -141,7 +148,7 @@ def test_non_strict_output(default_checker: len8.Checker) -> None:
 
 
 def test_non_strict_output_extended(default_checker: len8.Checker) -> None:
-    default_checker.extend = True
+    default_checker.extend = 2
     output = (
         "2 line(s) are too long:\n"
         f"- {TEST_FILE}, line 4 (76/72)\n"
@@ -208,3 +215,73 @@ def test_skip_invalid_files(default_checker: len8.Checker) -> None:
         default_checker.check(TEST_NON_VALID)
     except UnicodeDecodeError:
         pytest.fail()
+
+
+def test__check_dir(default_checker: len8.Checker) -> None:
+    default_checker._check(Path("tests"))
+
+
+def test_valid_config_init(valid_config: len8.Config) -> None:
+    assert isinstance(valid_config, len8.Config)
+    assert valid_config.include == ["tests/testdata.py"]
+    assert valid_config.exclude == ["tests/exclude.py"]
+    assert valid_config.code_length == 88
+    assert valid_config.docs_length == 69
+    assert valid_config.strict is True
+    assert valid_config.is_configured
+
+
+def test_invalid_config_init() -> None:
+    with pytest.raises(len8.ConfigurationError) as e:
+        _ = len8.Config(TEST_NON_VALID)
+
+    assert str(e.value) == (
+        f"'{TEST_NON_VALID}' is not a valid configuration file."
+    )
+
+
+def test_config_missing_len8() -> None:
+    config = len8.Config(TEST_LOL_TOML_CONFIG)
+
+    assert not config.is_configured
+    assert config.strict is False
+    assert config.docs_length is None
+    assert config.code_length is None
+    assert config.include is None
+    assert config.exclude is None
+
+
+def test_config_bad_toml_syntax() -> None:
+    p = "./tests/invalid.toml"
+    with open(p, "w") as f:
+        f.write("[tool.invalid_toml_syntax\n")
+
+    with pytest.raises(len8.ConfigurationError) as e:
+        _ = len8.Config(p)
+        assert "Failed to parse configuration file" in str(e.value)
+
+    Path(p).unlink()
+
+
+def test_checker_from_invalid_config() -> None:
+    with pytest.raises(len8.ConfigurationError) as e:
+        _ = len8.Checker.from_config(TEST_NON_VALID)
+
+    assert str(e.value) == (
+        f"'{TEST_NON_VALID}' is not a valid configuration file."
+    )
+
+
+def test_checker_from_valid_config(valid_config: len8.Config) -> None:
+    checker = len8.Checker.from_config(valid_config)
+
+    assert checker.code_length == 88
+    assert checker.docs_length == 69
+    assert checker.extend == 0
+    assert checker.strict is True
+    assert checker.exclude == [
+        Path(".nox"),
+        Path(".venv"),
+        Path("venv"),
+        Path("tests/exclude.py"),
+    ]

--- a/tests/test_lol.toml
+++ b/tests/test_lol.toml
@@ -1,0 +1,2 @@
+[tool.lol]
+laugh = true


### PR DESCRIPTION
### Summary
This pull request adds support for toml configuration files. It is supported via the cli, as well as the scripting api.

```toml
# myconfig.toml

[tool.len8]
include = ["len8"]
exclude = ["tests"]
code-length = 88
docs-length = 69
strict = true
```

```py
# main.py

from len8 import Checker, Config

# Valid
checker = Checker.from_config("./myconfig.toml")

# Also valid
checker = Checker.from_config(Path("./myconfig.toml"))

# Also valid
cfg = Config("./myconfig.toml")
checker = Checker.from_config(cfg)
```

Additions:
- `from_config` method added to `Checker`.
- `--config` cli flag added.
- `ConfigurationError` error added.
- Full test coverage.
- `__slots__` added to `Checker`.

Changes:
- `paths` is no longer a required cli arg, but an error is printed if it is not passed, and no `include` is found in the config file.
- `Checker._check` now handles `PermissionError` as well as `IsADirectoryError` as this is what's thrown on windows.
- setup.py updated to use a new parsing method for obtaining package metadata.

### Tasks
<!-- [ ] = No, [x] = Yes -->
- [x] I have searched for similar/duplicate PR's, and there are none.
- [x] I have made tests to validate any changes to the code base.
- [x] I have run `nox` and all sessions pass.

### Related issues
<!-- Related issues go here. `Closes #5` `Fixes #3` -->
Closes #18 